### PR TITLE
Require Python >=3.14.6 to exclude release candidates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "labase"
 version = "0.1.0"
 description = "SaaS base — FastAPI + Supabase + HTMX"
-requires-python = "~=3.14.0"
+requires-python = "~=3.14.6"
 dependencies = [
     "asyncpg==0.31.0",
     "fastapi==0.136.3",

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = "==3.14.*"
+requires-python = ">=3.14.6, <3.15"
 
 [[package]]
 name = "annotated-doc"


### PR DESCRIPTION
A 3.14.0 release candidate (3.14.0rc2) was satisfying `~=3.14.0` and
broke at import time: pydantic 2.13.4 passes `prefer_fwd_module=True`
to `typing._eval_type`, a parameter only present in the final 3.14
release, so every model raised TypeError on the RC.

Bumping the compatible-release floor to `~=3.14.6` keeps the project on
the 3.14 series (>=3.14.6, <3.15) while putting the floor above any
3.14.0 RC, so a release candidate can never satisfy the constraint.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0197Fbofd53BH79SkfMo5KXs