### PR TITLE
chore: drop unused SECRET_KEY from env files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,6 @@ DATABASE_URL_SERVICE=postgresql+asyncpg://postgres:postgres@host.docker.internal
 # DATABASE_URL=postgresql+asyncpg://app_user:password@db.your-project.supabase.co:5432/postgres
 # DATABASE_URL_SERVICE=postgresql+asyncpg://postgres:password@db.your-project.supabase.co:5432/postgres
 
-SECRET_KEY=change-me-in-production
 LOG_DEBUG=true
 COOKIES_SECURE=false
 RATE_LIMIT_ENABLED=false

--- a/.env.test
+++ b/.env.test
@@ -4,7 +4,6 @@ SUPABASE_SERVICE_ROLE_KEY=sb_secret_N7UND0UgjKTVK-Uodkm0Hg_xSvEMPvz
 DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:54322/postgres
 DATABASE_URL_SERVICE=postgresql+asyncpg://postgres:postgres@localhost:54322/postgres
 DB_SCHEMA=test
-SECRET_KEY=test-secret-key
 LOG_DEBUG=true
 COOKIES_SECURE=false
 RATE_LIMIT_ENABLED=false


### PR DESCRIPTION
## What

Remove the `SECRET_KEY` line from `.env.example` and `.env.test`.

## Why

- **Never read.** `TechnicalSettings` (`apps/shared/config.py`) has no `secret_key` field and is declared with `extra="ignore"`, so the variable was silently discarded at load time. A repo-wide search finds no reference to `SECRET_KEY` outside the env files.
- **Name collision.** It clashes with Supabase's own `sb_secret_*` API key surfaced by `supabase status`, which caused confusion about what actually belongs in `.env`.

No runtime behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)