### PR TITLE
style: commit a refined-neutral visual identity and enforce token hygiene

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,7 @@ lint:
 	npm run lint
 	uv run djlint apps --lint
 	uv run djlint apps --check
+	uv run python scripts/check_design_tokens.py
 	uv run pip-audit
 
 deadcode:

--- a/apps/auth/templates/accounts.html
+++ b/apps/auth/templates/accounts.html
@@ -7,7 +7,7 @@
 {% block content %}
   <div class="max-w-4xl space-y-6">
     <div>
-      <h1 class="text-lg font-semibold">Accounts</h1>
+      <h1 class="section-title">Accounts</h1>
       <p class="text-sm text-base-content/70 mt-0.5">
         Every server account, straight from Supabase Auth. Disabling bans sign-in;
         deleting follows the same path as self-serve account deletion.

--- a/apps/calendar/templates/calendar/_overview.html
+++ b/apps/calendar/templates/calendar/_overview.html
@@ -1,2 +1,2 @@
 {% from "macros/overview_card.html" import overview_card %}
-{{ overview_card(o, org_handle, color="primary") }}
+{{ overview_card(o, org_handle) }}

--- a/apps/calendar/templates/calendar/calendar.html
+++ b/apps/calendar/templates/calendar/calendar.html
@@ -7,7 +7,7 @@
 {% block content %}
   <div class="max-w-3xl space-y-6">
     <div class="flex items-center justify-between gap-4">
-      <h1 class="text-lg font-semibold">Calendar</h1>
+      <h1 class="section-title">Calendar</h1>
       <a href="/{{ org_handle }}/calendar/new"
          class="btn btn-primary btn-sm flex-none">
         <i class="ph ph-calendar-dots ph-4" aria-hidden="true"></i>
@@ -62,13 +62,13 @@
     </section>
     <!-- Agenda list -->
     <section aria-label="Events">
-      <h2 class="text-sm font-semibold mb-2">Events</h2>
+      <h2 class="subsection-title mb-2">Events</h2>
       <div id="event-list" class="space-y-5">
         {% if not has_events %}<p class="text-xs opacity-60" data-empty>No events yet.</p>{% endif %}
         {% for group in agenda %}
           <div>
-            <h3 class="text-xs font-semibold uppercase tracking-wide text-base-content/70 mb-1">{{ group.label }}</h3>
-            <ul class="bg-base-100 border border-base-300 rounded-box overflow-hidden divide-y divide-base-300 shadow-sm">
+            <h3 class="eyebrow mb-1">{{ group.label }}</h3>
+            <ul class="list-panel">
               {% for ev in group.events %}
                 <li class="flex items-center gap-3 px-4 py-3">
                   <span class="text-sm text-base-content/70 tabular-nums w-28 flex-none">{{ ev.time }}</span>

--- a/apps/calendar/templates/calendar/form.html
+++ b/apps/calendar/templates/calendar/form.html
@@ -22,7 +22,7 @@
 {% from "macros/alert.html" import alert %}
 {% block content %}
   <div class="max-w-xl space-y-6">
-    <h1 class="text-lg font-semibold">
+    <h1 class="section-title">
       {% if is_edit %}
         Edit event
       {% else %}

--- a/apps/calendar/templates/calendar/view.html
+++ b/apps/calendar/templates/calendar/view.html
@@ -8,7 +8,7 @@
 {% block content %}
   <div class="max-w-xl space-y-6">
     <div class="flex items-center justify-between gap-4">
-      <h1 class="text-lg font-semibold">{{ event.title }}</h1>
+      <h1 class="section-title">{{ event.title }}</h1>
       <div class="flex items-center gap-2 flex-none">
         <a href="/{{ org_handle }}/calendar/{{ event.id }}/edit"
            class="btn btn-sm">

--- a/apps/console/contract/appearance.py
+++ b/apps/console/contract/appearance.py
@@ -12,10 +12,16 @@ from apps.shared.settings import get_settings
 
 THEME_APP = "appearance"
 THEME_KEY = "theme"
-DEFAULT_THEME = "light"
+DEFAULT_THEME = "labase-light"
 
-# The themes enabled in static/css/input.css (@plugin "daisyui" { themes: ... }).
+# The themes available in static/css/input.css. The two `labase-*` names are custom
+# themes declared with `@plugin "daisyui/theme"` (they carry the product identity and
+# are the light/dark defaults); the rest are the built-in daisyUI themes kept enabled
+# in the `@plugin "daisyui" { themes: ... }` block as an admin-selectable roster.
+# `scripts/check_design_tokens.py` asserts this list stays in sync with input.css.
 THEMES = [
+    "labase-light",
+    "labase-dark",
     "light",
     "dark",
     "cupcake",

--- a/apps/console/templates/console.html
+++ b/apps/console/templates/console.html
@@ -7,7 +7,7 @@
   <div class="space-y-6">
     <div class="flex items-start justify-between">
       <div>
-        <h1 class="text-lg font-semibold">Admin console</h1>
+        <h1 class="section-title">Admin console</h1>
         <p class="text-sm text-base-content/70 mt-0.5">Server-wide — every organisation. Click an app to configure it.</p>
       </div>
       <div class="flex gap-2">
@@ -17,8 +17,7 @@
     </div>
     {% for section in sections %}
       <section class="space-y-3" aria-labelledby="console-section-{{ section.key }}">
-        <h2 id="console-section-{{ section.key }}"
-            class="text-xs font-semibold uppercase tracking-wide text-base-content/50">{{ section.label }}</h2>
+        <h2 id="console-section-{{ section.key }}" class="eyebrow">{{ section.label }}</h2>
         <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {% for o in section.overviews %}
             <a href="{{ o.href or '/console/' ~ o.key }}"

--- a/apps/console/templates/console/_styleguide.html
+++ b/apps/console/templates/console/_styleguide.html
@@ -16,7 +16,7 @@
   <!-- Charts -->
   <div x-show="sub === 'charts'" x-cloak class="space-y-12">
     <section id="sg-charts" aria-labelledby="sg-charts-h" class="space-y-4">
-      <h2 id="sg-charts-h" class="text-lg font-semibold">Charts</h2>
+      <h2 id="sg-charts-h" class="section-title">Charts</h2>
       <p class="text-sm text-base-content/70">
         ApexCharts, themed from the daisyUI variables — switch the theme above and they recolor live.
       </p>
@@ -158,16 +158,21 @@
     <section id="sg-typography"
              aria-labelledby="sg-typography-h"
              class="space-y-3">
-      <h2 id="sg-typography-h" class="text-lg font-semibold">Typography</h2>
-      <h1 class="text-3xl font-bold">Heading 1</h1>
-      <h2 class="text-2xl font-semibold">Heading 2</h2>
-      <h3 class="text-xl font-semibold">Heading 3</h3>
-      <p class="text-base">
+      <h2 id="sg-typography-h" class="section-title">Typography</h2>
+      <p class="text-sm text-base-content/70">
+        The shared type ramp — templates use these classes instead of hand-spelling sizes.
+      </p>
+      <div class="space-y-2">
+        <p class="page-title">Page title <span class="meta-text font-normal normal-case tracking-normal">.page-title</span></p>
+        <p class="section-title">Section title <span class="meta-text font-normal">.section-title</span></p>
+        <p class="subsection-title">Subsection title <span class="meta-text font-normal">.subsection-title</span></p>
+        <p class="eyebrow">Eyebrow label <span class="meta-text font-normal normal-case tracking-normal">.eyebrow</span></p>
+        <p class="meta-text">Meta text — .meta-text</p>
+      </div>
+      <p class="text-base pt-2">
         Body text with a <a class="link link-primary" href="#">primary link</a> and some
         <code class="text-sm">inline code</code>.
       </p>
-      <p class="text-sm text-base-content/70">Muted secondary text.</p>
-      <p class="text-xs text-base-content/50">Small meta text.</p>
       <div class="flex flex-wrap items-center gap-2">
         <kbd class="kbd">⌘</kbd><kbd class="kbd">K</kbd>
         <span class="text-sm text-base-content/60">keyboard keys</span>
@@ -177,7 +182,7 @@
   <!-- Actions -->
   <div x-show="sub === 'actions'" x-cloak class="space-y-12">
     <section id="sg-buttons" aria-labelledby="sg-buttons-h" class="space-y-4">
-      <h2 id="sg-buttons-h" class="text-lg font-semibold">Buttons</h2>
+      <h2 id="sg-buttons-h" class="section-title">Buttons</h2>
       <div class="flex flex-wrap gap-3">
         <button class="btn">Default</button>
         <button class="btn btn-primary">Primary</button>
@@ -206,7 +211,7 @@
       </div>
     </section>
     <section id="sg-badges" aria-labelledby="sg-badges-h" class="space-y-4">
-      <h2 id="sg-badges-h" class="text-lg font-semibold">Badges</h2>
+      <h2 id="sg-badges-h" class="section-title">Badges</h2>
       <div class="flex flex-wrap items-center gap-3">
         <span class="badge">neutral</span>
         <span class="badge badge-primary">primary</span>
@@ -223,7 +228,7 @@
       </div>
     </section>
     <section id="sg-steps" aria-labelledby="sg-steps-h" class="space-y-4">
-      <h2 id="sg-steps-h" class="text-lg font-semibold">Steps</h2>
+      <h2 id="sg-steps-h" class="section-title">Steps</h2>
       <ul class="steps">
         <li class="step step-primary">Register</li>
         <li class="step step-primary">Verify</li>
@@ -235,7 +240,7 @@
   <!-- Forms -->
   <div x-show="sub === 'forms'" x-cloak class="space-y-12">
     <section id="sg-forms" aria-labelledby="sg-forms-h" class="space-y-4">
-      <h2 id="sg-forms-h" class="text-lg font-semibold">Forms</h2>
+      <h2 id="sg-forms-h" class="section-title">Forms</h2>
       <div class="grid gap-4 md:grid-cols-2">
         <div class="card-panel">
           <div class="card-body gap-4">
@@ -280,7 +285,7 @@
       </div>
     </section>
     <section id="sg-toggles" aria-labelledby="sg-toggles-h" class="space-y-4">
-      <h2 id="sg-toggles-h" class="text-lg font-semibold">Toggles &amp; checks</h2>
+      <h2 id="sg-toggles-h" class="section-title">Toggles &amp; checks</h2>
       <div class="flex flex-wrap items-center gap-6">
         <label class="label cursor-pointer gap-3">
           <input type="checkbox" class="toggle toggle-primary" checked />
@@ -301,7 +306,7 @@
       </div>
     </section>
     <section id="sg-rating" aria-labelledby="sg-rating-h" class="space-y-4">
-      <h2 id="sg-rating-h" class="text-lg font-semibold">Rating</h2>
+      <h2 id="sg-rating-h" class="section-title">Rating</h2>
       <div class="rating" aria-label="Rating">
         <input type="radio"
                name="sg-rating"
@@ -330,7 +335,7 @@
   <!-- Data -->
   <div x-show="sub === 'data'" x-cloak class="space-y-12">
     <section id="sg-stats" aria-labelledby="sg-stats-h" class="space-y-4">
-      <h2 id="sg-stats-h" class="text-lg font-semibold">Stats</h2>
+      <h2 id="sg-stats-h" class="section-title">Stats</h2>
       <div class="stats stats-vertical sm:stats-horizontal bg-base-100 border border-base-300 w-full">
         <div class="stat">
           <div class="stat-title">Members</div>
@@ -349,13 +354,13 @@
         </div>
       </div>
       <div class="grid gap-4 sm:grid-cols-3">
-        {{ metric_card('Members', 'indigo', 'users') }}
-        {{ metric_card('Storage', 'emerald', 'folder') }}
-        {{ metric_card('Pending', 'amber', 'clipboard-text') }}
+        {{ metric_card('Members', 'users') }}
+        {{ metric_card('Storage', 'folder') }}
+        {{ metric_card('Pending', 'clipboard-text') }}
       </div>
     </section>
     <section id="sg-cards" aria-labelledby="sg-cards-h" class="space-y-4">
-      <h2 id="sg-cards-h" class="text-lg font-semibold">Cards</h2>
+      <h2 id="sg-cards-h" class="section-title">Cards</h2>
       <div class="grid gap-4 sm:grid-cols-2">
         <div class="card-panel">
           <div class="card-body">
@@ -375,7 +380,7 @@
       </div>
     </section>
     <section id="sg-table" aria-labelledby="sg-table-h" class="space-y-4">
-      <h2 id="sg-table-h" class="text-lg font-semibold">Table</h2>
+      <h2 id="sg-table-h" class="section-title">Table</h2>
       <div class="overflow-x-auto rounded-box border border-base-300">
         <table class="table table-zebra">
           <thead>
@@ -406,7 +411,7 @@
       </div>
     </section>
     <section id="sg-avatar" aria-labelledby="sg-avatar-h" class="space-y-4">
-      <h2 id="sg-avatar-h" class="text-lg font-semibold">Avatars</h2>
+      <h2 id="sg-avatar-h" class="section-title">Avatars</h2>
       <div class="flex items-center gap-4">
         <div class="avatar avatar-placeholder">
           <div class="w-12 rounded-full bg-primary/20 text-primary">
@@ -432,7 +437,7 @@
       </div>
     </section>
     <section id="sg-timeline" aria-labelledby="sg-timeline-h" class="space-y-4">
-      <h2 id="sg-timeline-h" class="text-lg font-semibold">Timeline</h2>
+      <h2 id="sg-timeline-h" class="section-title">Timeline</h2>
       <ul class="timeline timeline-vertical">
         <li>
           <div class="timeline-start">2024</div>
@@ -465,14 +470,14 @@
   <!-- Feedback -->
   <div x-show="sub === 'feedback'" x-cloak class="space-y-12">
     <section id="sg-alerts" aria-labelledby="sg-alerts-h" class="space-y-4">
-      <h2 id="sg-alerts-h" class="text-lg font-semibold">Alerts</h2>
+      <h2 id="sg-alerts-h" class="section-title">Alerts</h2>
       {{ alert('info', 'Informational message.') }}
       {{ alert('success', 'Saved successfully.') }}
       {{ alert('error', 'Something went wrong.') }}
       <div class="alert alert-warning" role="alert">A warning with no macro.</div>
     </section>
     <section id="sg-progress" aria-labelledby="sg-progress-h" class="space-y-4">
-      <h2 id="sg-progress-h" class="text-lg font-semibold">Progress &amp; Loading</h2>
+      <h2 id="sg-progress-h" class="section-title">Progress &amp; Loading</h2>
       <progress class="progress progress-primary w-full max-w-md"
                 value="40"
                 max="100"></progress>
@@ -490,7 +495,7 @@
       </div>
     </section>
     <section id="sg-feedback" aria-labelledby="sg-feedback-h" class="space-y-4">
-      <h2 id="sg-feedback-h" class="text-lg font-semibold">Tooltip &amp; Indicator</h2>
+      <h2 id="sg-feedback-h" class="section-title">Tooltip &amp; Indicator</h2>
       <div class="flex flex-wrap items-center gap-8 pt-2">
         <div class="tooltip" data-tip="Hello there">
           <button class="btn">Hover me</button>
@@ -505,7 +510,7 @@
       </div>
     </section>
     <section id="sg-skeleton" aria-labelledby="sg-skeleton-h" class="space-y-4">
-      <h2 id="sg-skeleton-h" class="text-lg font-semibold">Skeleton</h2>
+      <h2 id="sg-skeleton-h" class="section-title">Skeleton</h2>
       <div class="flex items-center gap-4 max-w-md">
         <div class="skeleton h-12 w-12 shrink-0 rounded-full"></div>
         <div class="flex flex-col gap-2 w-full">
@@ -515,7 +520,7 @@
       </div>
     </section>
     <section id="sg-chat" aria-labelledby="sg-chat-h" class="space-y-4">
-      <h2 id="sg-chat-h" class="text-lg font-semibold">Chat</h2>
+      <h2 id="sg-chat-h" class="section-title">Chat</h2>
       <div class="chat chat-start">
         <div class="chat-bubble">Hi! How does the new theme look?</div>
       </div>
@@ -527,7 +532,7 @@
   <!-- Navigation -->
   <div x-show="sub === 'navigation'" x-cloak class="space-y-12">
     <section id="sg-tabs" aria-labelledby="sg-tabs-h" class="space-y-4">
-      <h2 id="sg-tabs-h" class="text-lg font-semibold">Tabs</h2>
+      <h2 id="sg-tabs-h" class="section-title">Tabs</h2>
       <div role="tablist" class="tabs tabs-box">
         <a role="tab" class="tab tab-active">Overview</a>
         <a role="tab" class="tab">Members</a>
@@ -540,7 +545,7 @@
       </div>
     </section>
     <section id="sg-menu" aria-labelledby="sg-menu-h" class="space-y-4">
-      <h2 id="sg-menu-h" class="text-lg font-semibold">Menu</h2>
+      <h2 id="sg-menu-h" class="section-title">Menu</h2>
       <ul class="menu bg-base-100 rounded-box border border-base-300 w-56">
         <li><a class="menu-active"><i class="ph ph-gear ph-sm" aria-hidden="true"></i>Active</a></li>
         <li><a><i class="ph ph-users ph-sm" aria-hidden="true"></i>Members</a></li>
@@ -550,7 +555,7 @@
     <section id="sg-navigation"
              aria-labelledby="sg-navigation-h"
              class="space-y-4">
-      <h2 id="sg-navigation-h" class="text-lg font-semibold">Breadcrumbs &amp; Pagination</h2>
+      <h2 id="sg-navigation-h" class="section-title">Breadcrumbs &amp; Pagination</h2>
       <nav class="breadcrumbs text-sm" aria-label="Breadcrumb">
         <ul>
           <li><a>Home</a></li>
@@ -567,7 +572,7 @@
       </div>
     </section>
     <section id="sg-overlays" aria-labelledby="sg-overlays-h" class="space-y-4">
-      <h2 id="sg-overlays-h" class="text-lg font-semibold">Dropdown &amp; Modal</h2>
+      <h2 id="sg-overlays-h" class="section-title">Dropdown &amp; Modal</h2>
       <div class="flex flex-wrap gap-3">
         <div class="dropdown">
           <div tabindex="0" role="button" class="btn">Dropdown</div>
@@ -580,7 +585,7 @@
         <button class="btn" onclick="sg_modal.showModal()">Open modal</button>
         <dialog id="sg_modal" class="modal">
           <div class="modal-box">
-            <h3 class="text-lg font-semibold">Hello</h3>
+            <h3 class="section-title">Hello</h3>
             <p class="py-4 text-sm text-base-content/70">A native &lt;dialog&gt; styled by DaisyUI.</p>
             <div class="modal-action">
               <form method="dialog">
@@ -595,7 +600,7 @@
       </div>
     </section>
     <section id="sg-accordion" aria-labelledby="sg-accordion-h" class="space-y-4">
-      <h2 id="sg-accordion-h" class="text-lg font-semibold">Accordion</h2>
+      <h2 id="sg-accordion-h" class="section-title">Accordion</h2>
       <div class="join join-vertical w-full">
         <div class="collapse collapse-arrow join-item border border-base-300 bg-base-100">
           <input type="radio" name="sg-accordion" checked />

--- a/apps/console/templates/console/admins.html
+++ b/apps/console/templates/console/admins.html
@@ -7,7 +7,7 @@
 {% block content %}
   <div class="max-w-2xl space-y-6">
     <div>
-      <h1 class="text-lg font-semibold">Server admins</h1>
+      <h1 class="section-title">Server admins</h1>
       <p class="text-sm text-base-content/70 mt-0.5">
         Admins oversee every organisation and configure each app. {{ admin_count }} admin{{ 's' if admin_count != 1 else '' }}.
       </p>

--- a/apps/console/templates/console/app.html
+++ b/apps/console/templates/console/app.html
@@ -6,7 +6,7 @@
 {% endblock %}
 {% block content %}
   <div class="max-w-2xl space-y-6">
-    <h1 class="text-lg font-semibold">{{ app }}</h1>
+    <h1 class="section-title">{{ app }}</h1>
     {% if links %}
       <div class="flex flex-wrap gap-2">
         {% for link in links %}

--- a/apps/console/templates/console/settings.html
+++ b/apps/console/templates/console/settings.html
@@ -9,7 +9,7 @@
        x-data="{ tab: 'appearance', syncTabFromHash() { const h = window.location.hash.slice(1); this.tab = ['appearance', 'technical'].includes(h) ? h : 'appearance' } }"
        x-init=" syncTabFromHash(); window.addEventListener('hashchange', () => syncTabFromHash()) ">
     <div>
-      <h1 class="text-lg font-semibold">Settings</h1>
+      <h1 class="section-title">Settings</h1>
       <p class="text-sm text-base-content/70 mt-0.5">
         Server-wide — appearance, environment and process. Logs and their level live on the
         <a class="link" href="/console/logs">logs screen</a>.

--- a/apps/console/tests/test_console_styleguide.py
+++ b/apps/console/tests/test_console_styleguide.py
@@ -12,4 +12,4 @@ def test_appearance_tab_renders_component_gallery(driver):
 def test_appearance_tab_applies_app_theme(driver):
     driver.sign_in_as_admin("styleguide-admin2@example.com")
     body = driver.client().get("/console/settings", headers={"accept": "text/html"}).text
-    assert 'data-theme="light"' in body
+    assert 'data-theme="labase-light"' in body

--- a/apps/files/templates/files/_overview.html
+++ b/apps/files/templates/files/_overview.html
@@ -1,2 +1,2 @@
 {% from "macros/overview_card.html" import overview_card %}
-{{ overview_card(o, org_handle, color="success") }}
+{{ overview_card(o, org_handle) }}

--- a/apps/files/templates/files/files.html
+++ b/apps/files/templates/files/files.html
@@ -6,7 +6,7 @@
 {% endblock %}
 {% block content %}
   <div class="max-w-2xl space-y-6">
-    <h1 class="text-lg font-semibold">Organisation files</h1>
+    <h1 class="section-title">Organisation files</h1>
     {% if welcome_message %}
       <p class="text-sm text-base-content/70">{{ welcome_message }}</p>
     {% endif %}

--- a/apps/issues/templates/issues/detail.html
+++ b/apps/issues/templates/issues/detail.html
@@ -9,7 +9,7 @@
   <div class="max-w-4xl space-y-6">
     <a href="/console/issues" class="text-sm text-primary hover:underline">← Issues</a>
     <div>
-      <h1 class="text-lg font-semibold font-mono break-all">{{ group.title }}</h1>
+      <h1 class="section-title font-mono break-all">{{ group.title }}</h1>
       <p class="text-sm text-base-content/70 mt-0.5">
         ×{{ group.count }} · first seen {{ group.first_seen.strftime("%Y-%m-%d %H:%M") }}
         ({{ group.first_version }}) · last seen {{ group.last_seen.strftime("%Y-%m-%d %H:%M") }}

--- a/apps/issues/templates/issues/index.html
+++ b/apps/issues/templates/issues/index.html
@@ -8,7 +8,7 @@
 {% block content %}
   <div class="max-w-4xl space-y-6">
     <div>
-      <h1 class="text-lg font-semibold">Issues</h1>
+      <h1 class="section-title">Issues</h1>
       <p class="text-sm text-base-content/70 mt-0.5">
         Captured errors, grouped by stack fingerprint. The request id of each event
         links it to the structured logs.

--- a/apps/learning/templates/learning/_overview.html
+++ b/apps/learning/templates/learning/_overview.html
@@ -1,2 +1,2 @@
 {% from "macros/overview_card.html" import overview_card %}
-{{ overview_card(o, org_handle, color="warning") }}
+{{ overview_card(o, org_handle) }}

--- a/apps/learning/templates/learning/resources.html
+++ b/apps/learning/templates/learning/resources.html
@@ -6,7 +6,7 @@
 {% endblock %}
 {% block content %}
   <div class="max-w-2xl space-y-6">
-    <h1 class="text-lg font-semibold">Resources to review</h1>
+    <h1 class="section-title">Resources to review</h1>
     <ul id="learning-resources" class="list-panel">
       {% for item in resources %}
         <li class="flex gap-2 px-4 py-2 text-sm"

--- a/apps/learning/templates/learning/session.html
+++ b/apps/learning/templates/learning/session.html
@@ -7,7 +7,7 @@
 {% block content %}
   <div class="max-w-2xl space-y-6">
     <div class="flex items-center justify-between">
-      <h1 class="text-lg font-semibold">Review session</h1>
+      <h1 class="section-title">Review session</h1>
       <a href="/{{ org_handle }}/learning/resources" class="btn btn-sm">Resources to review</a>
     </div>
     {% include "learning/_session_fragment.html" %}

--- a/apps/logs/templates/logs/index.html
+++ b/apps/logs/templates/logs/index.html
@@ -9,7 +9,7 @@
   <div class="max-w-6xl space-y-6">
     <div class="flex flex-wrap items-start justify-between gap-4">
       <div>
-        <h1 class="text-lg font-semibold">Logs</h1>
+        <h1 class="section-title">Logs</h1>
         <p class="text-sm text-base-content/70 mt-0.5 max-w-2xl">
           One timeline across every source — the structlog firehose, the audit trail and tracked
           issues — server-wide. Correlate by request id.
@@ -39,7 +39,7 @@
       <div class="p-4 border-b border-base-300"
            data-activity='{{ activity | tojson }}'>
         <div class="flex items-center gap-4 mb-3">
-          <span class="text-xs font-semibold uppercase tracking-wide text-base-content/60">Activity</span>
+          <span class="eyebrow">Activity</span>
           <span class="flex gap-3 text-xs text-base-content/60">
             <span class="inline-flex items-center gap-1.5"><span class="w-2.5 h-2.5 rounded-sm bg-info"></span>request</span>
             <span class="inline-flex items-center gap-1.5"><span class="w-2.5 h-2.5 rounded-sm bg-secondary"></span>audit</span>

--- a/apps/metrics/templates/metrics/load.html
+++ b/apps/metrics/templates/metrics/load.html
@@ -7,7 +7,7 @@
 {% block content %}
   <div class="max-w-4xl space-y-6">
     <div>
-      <h1 class="text-lg font-semibold">Metrics</h1>
+      <h1 class="section-title">Metrics</h1>
       <p class="text-sm text-base-content/70 mt-0.5">
         HTTP traffic over the last {{ window_hours }} hours, aggregated per route
         across all instances. Percentiles come from histogram buckets, Prometheus-style.

--- a/apps/organizations/templates/invitations/accept.html
+++ b/apps/organizations/templates/invitations/accept.html
@@ -18,7 +18,7 @@
       <div class="card-panel">
         <div class="card-body p-8">
           {% if state in ("valid", "valid_login", "valid_register") %}
-            <h2 class="text-lg font-semibold mb-1">You have been invited</h2>
+            <h2 class="section-title mb-1">You have been invited</h2>
             <p class="text-sm text-base-content/70 mb-6">
               Join <strong>{{ org_name }}</strong> as a member.
               {% if email %}

--- a/apps/organizations/templates/organizations/dashboard.html
+++ b/apps/organizations/templates/organizations/dashboard.html
@@ -7,7 +7,7 @@
 {% block content %}
   <div class="space-y-6">
     <div>
-      <h1 class="text-lg font-semibold">Overview</h1>
+      <h1 class="section-title">Overview</h1>
       <p class="text-sm text-base-content/70 mt-0.5">Welcome, {{ profile_handle }}</p>
     </div>
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">

--- a/apps/organizations/templates/organizations/members.html
+++ b/apps/organizations/templates/organizations/members.html
@@ -6,7 +6,7 @@
 {% endblock %}
 {% block content %}
   <div class="max-w-2xl space-y-6">
-    <h1 class="text-lg font-semibold">{{ org.name }} — Members</h1>
+    <h1 class="section-title">{{ org.name }} — Members</h1>
     {% include "organizations/_members_panel.html" %}
   </div>
 {% endblock %}

--- a/apps/organizations/templates/organizations/settings.html
+++ b/apps/organizations/templates/organizations/settings.html
@@ -9,7 +9,7 @@
 {% block content %}
   <div class="max-w-2xl space-y-6">
     <div>
-      <h1 class="text-lg font-semibold" data-org-name="{{ org.name }}">{{ org.name }}</h1>
+      <h1 class="section-title" data-org-name="{{ org.name }}">{{ org.name }}</h1>
       <p class="text-sm text-base-content/70 mt-0.5">
         Your role:
         {{ role_badge(role) }}

--- a/apps/pages/templates/pages/_overview.html
+++ b/apps/pages/templates/pages/_overview.html
@@ -1,2 +1,2 @@
 {% from "macros/overview_card.html" import overview_card %}
-{{ overview_card(o, org_handle, color="primary") }}
+{{ overview_card(o, org_handle) }}

--- a/apps/pages/templates/pages/form.html
+++ b/apps/pages/templates/pages/form.html
@@ -8,7 +8,7 @@
 {% endblock %}
 {% block content %}
   <div class="max-w-2xl space-y-6">
-    <h1 class="text-lg font-semibold">Edit page</h1>
+    <h1 class="section-title">Edit page</h1>
     <form id="edit-page-form"
           class="card-panel"
           hx-patch="/{{ org_handle }}/pages/{{ page.slug }}"

--- a/apps/pages/templates/pages/nav.html
+++ b/apps/pages/templates/pages/nav.html
@@ -8,7 +8,7 @@
 {% block content %}
   <div class="max-w-2xl space-y-6">
     <div>
-      <h1 class="text-lg font-semibold">Navigation</h1>
+      <h1 class="section-title">Navigation</h1>
       <p class="text-sm text-base-content/70 mt-1">Check pages to include them. Drag to reorder.</p>
     </div>
     <ul id="nav-list" class="list-panel">

--- a/apps/pages/templates/pages/pages.html
+++ b/apps/pages/templates/pages/pages.html
@@ -7,7 +7,7 @@
 {% block content %}
   <div class="max-w-2xl space-y-6">
     <div class="flex items-center justify-between">
-      <h1 class="text-lg font-semibold">Pages</h1>
+      <h1 class="section-title">Pages</h1>
       <div class="flex items-center gap-2">
         {% if is_owner %}
           <a href="/{{ org_handle }}/pages/nav" class="btn">Manage navigation</a>

--- a/apps/pages/templates/pages/public_list.html
+++ b/apps/pages/templates/pages/public_list.html
@@ -19,7 +19,7 @@
       <span class="text-sm text-base-content/70 font-medium truncate">{{ org.name }}</span>
     </header>
     <main class="max-w-2xl mx-auto px-6 py-10">
-      <h1 class="text-2xl font-semibold mb-6">Pages</h1>
+      <h1 class="page-title mb-6">Pages</h1>
       {% if pages %}
         <ul id="pages-list" class="list-panel">
           {% for p in pages %}

--- a/apps/pages/templates/pages/view.html
+++ b/apps/pages/templates/pages/view.html
@@ -8,7 +8,7 @@
 {% block content %}
   <article class="min-w-0 max-w-2xl space-y-6">
     <div class="flex items-center justify-between gap-4">
-      <h1 class="text-lg font-semibold">{{ page.title }}</h1>
+      <h1 class="section-title">{{ page.title }}</h1>
       {% if can_edit %}
         <a href="/{{ org_handle }}/pages/{{ page.slug }}/edit"
            class="btn btn-sm flex-none">

--- a/apps/pages/templates/pages/view_public.html
+++ b/apps/pages/templates/pages/view_public.html
@@ -19,7 +19,7 @@
     <main class="px-8 py-10 max-w-2xl min-h-[calc(100vh-3.5rem)]">
       <article class="space-y-6">
         <div class="flex items-start justify-between gap-4">
-          <h1 class="text-2xl font-semibold">{{ page.title }}</h1>
+          <h1 class="page-title">{{ page.title }}</h1>
           {% if can_edit %}
             <a href="/{{ org_handle }}/pages/{{ page.slug }}/edit"
                class="btn btn-sm flex-none">

--- a/apps/profile/templates/profile.html
+++ b/apps/profile/templates/profile.html
@@ -8,7 +8,7 @@
 {% block content %}
   <div class="space-y-6 max-w-2xl">
     <div>
-      <h1 class="text-lg font-semibold">Profile</h1>
+      <h1 class="section-title">Profile</h1>
       <p class="text-sm text-base-content/70 mt-0.5">Manage your personal information.</p>
     </div>
     {# Keep the tab that owns a just-rendered alert/enrolment open across the

--- a/apps/public/templates/base_public.html
+++ b/apps/public/templates/base_public.html
@@ -14,10 +14,10 @@
     <header class="navbar min-h-14 px-4">
       <div class="flex-1">
         <a href="/" class="flex items-center gap-2.5">
-          <div class="flex h-9 w-9 items-center justify-center rounded-xl bg-primary text-primary-content shadow-lg shadow-primary/25">
+          <div class="flex h-9 w-9 items-center justify-center rounded-xl bg-primary text-primary-content">
             <i class="ph ph-lightning ph-md" aria-hidden="true"></i>
           </div>
-          <span class="text-xl font-bold tracking-tight">labase</span>
+          <span class="text-xl font-semibold tracking-tight">labase</span>
         </a>
       </div>
     </header>

--- a/apps/public/templates/public_page.html
+++ b/apps/public/templates/public_page.html
@@ -70,7 +70,7 @@
         </header>
         <main class="flex-1 p-6 overflow-auto">
           <div class="max-w-2xl mx-auto space-y-6">
-            <h1 class="text-2xl font-semibold">{{ page.title }}</h1>
+            <h1 class="page-title">{{ page.title }}</h1>
             <div class="card-panel">
               <div class="card-body">
                 <div class="md-body">{{ body | safe }}</div>

--- a/apps/shared/templates/errors/error.html
+++ b/apps/shared/templates/errors/error.html
@@ -3,7 +3,7 @@
 {% block content %}
   <div class="text-center">
     <p class="text-7xl font-bold text-primary mb-4">{{ status_code }}</p>
-    <h1 class="text-2xl font-semibold mb-2">{{ title }}</h1>
+    <h1 class="page-title mb-2">{{ title }}</h1>
     {% if detail %}
       <p class="text-sm text-base-content/60 mb-6">{{ detail }}</p>
     {% endif %}

--- a/apps/shared/templates/macros/metric_card.html
+++ b/apps/shared/templates/macros/metric_card.html
@@ -1,7 +1,6 @@
-{% macro metric_card(label, color, icon) %}
-  {% set fig = {"indigo": "text-primary", "emerald": "text-success", "amber": "text-warning"} %}
+{% macro metric_card(label, icon) %}
   <div class="stat bg-base-100 border border-base-300 rounded-box">
-    <div class="stat-figure {{ fig[color] }}">
+    <div class="stat-figure text-primary">
       <i class="ph ph-{{ icon }} ph-lg" aria-hidden="true"></i>
     </div>
     <div class="stat-title">{{ label }}</div>

--- a/apps/shared/templates/macros/overview_card.html
+++ b/apps/shared/templates/macros/overview_card.html
@@ -1,12 +1,12 @@
-{% macro overview_card(o, org_handle, color="primary") %}
+{% macro overview_card(o, org_handle) %}
   <section class="card-panel transition duration-200 hover:-translate-y-0.5 hover:shadow-md"
            data-overview="{{ o.key }}">
     <div class="card-body">
       <div class="flex items-center gap-3 mb-3">
-        <div class="w-9 h-9 rounded-xl bg-{{ color }}/10 flex items-center justify-center flex-none">
-          <i class="ph ph-{{ o.icon }} text-{{ color }}" aria-hidden="true"></i>
+        <div class="icon-badge">
+          <i class="ph ph-{{ o.icon }}" aria-hidden="true"></i>
         </div>
-        <h3 class="card-title text-sm font-semibold">{{ o.title }}</h3>
+        <h3 class="subsection-title">{{ o.title }}</h3>
       </div>
       <div class="flex flex-wrap gap-2 mb-2">
         {% for line in o.data.lines %}

--- a/apps/todo/templates/todo/_overview.html
+++ b/apps/todo/templates/todo/_overview.html
@@ -1,2 +1,2 @@
 {% from "macros/overview_card.html" import overview_card %}
-{{ overview_card(o, org_handle, color="primary") }}
+{{ overview_card(o, org_handle) }}

--- a/apps/todo/templates/todo/list.html
+++ b/apps/todo/templates/todo/list.html
@@ -6,7 +6,7 @@
 {% endblock %}
 {% block content %}
   <div class="max-w-2xl space-y-6">
-    <h1 class="text-lg font-semibold">Todos</h1>
+    <h1 class="section-title">Todos</h1>
     {% if creation_enabled %}
       <form hx-post="/{{ org_handle }}/todos"
             hx-target="#todo-list"

--- a/scripts/check_design_tokens.py
+++ b/scripts/check_design_tokens.py
@@ -1,0 +1,124 @@
+"""Design-token guard — `make lint` calls this to keep the styling system honest.
+
+The base has one styling source of truth: daisyUI semantic tokens (base-*, primary,
+success…) driven by the active theme. Two ways that truth erodes over time, both caught
+here so a regression fails CI instead of shipping:
+
+1. **Raw palette / hex colours.** A `text-gray-500` or a `#1e1e2e` bypasses the token
+   system: it ignores the active theme and breaks under the dark / non-default themes.
+   Templates must use semantic tokens; the same holds for the component layer in
+   ``static/css/input.css``. (Transactional *email* templates are exempt — mail clients
+   can't resolve CSS variables, so inline hex there is correct.)
+
+2. **Theme-list drift.** The themes offered to admins are declared twice — in
+   ``input.css`` (the two custom ``@plugin "daisyui/theme"`` blocks plus the built-in
+   ``themes:`` roster) and in ``apps/console/contract/appearance.py`` (``THEMES``). If the
+   two disagree the console can offer a theme the CSS never built, or vice-versa. This
+   asserts they are the same set.
+
+Read-only. Exits non-zero (and prints every offence) on any violation.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+INPUT_CSS = ROOT / "static" / "css" / "input.css"
+APPEARANCE = ROOT / "apps" / "console" / "contract" / "appearance.py"
+
+_PALETTE_NAMES = (
+    "slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|"
+    "teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose"
+)
+# e.g. text-gray-500, bg-indigo-600, border-slate-200 — a Tailwind palette utility with a
+# numeric shade. daisyUI tokens (bg-primary, text-base-content, bg-neutral) carry no
+# numeric shade, so they never match.
+RAW_PALETTE = re.compile(
+    r"\b(?:text|bg|border|ring|ring-offset|from|via|to|divide|fill|stroke|outline|"
+    r"shadow|decoration|accent|caret)-(?:" + _PALETTE_NAMES + r")-"
+    r"(?:50|100|200|300|400|500|600|700|800|900|950)\b"
+)
+# CSS hex literal. Phosphor glyph escapes (content: "\e058") use a backslash, not a
+# hash, so they never match.
+HEX = re.compile(r"#[0-9a-fA-F]{3,8}\b")
+
+
+def _iter_template_files():
+    """Served Jinja templates, minus email bodies (inline hex there is legitimate)."""
+    for path in (ROOT / "apps").rglob("*.html"):
+        parts = set(path.parts)
+        if "templates" in parts and "email" not in parts:
+            yield path
+
+
+def scan_colours() -> list[str]:
+    offences: list[str] = []
+    targets = [*_iter_template_files(), INPUT_CSS]
+    for path in targets:
+        rel = path.relative_to(ROOT)
+        text = path.read_text(encoding="utf-8")
+        for lineno, line in enumerate(text.splitlines(), 1):
+            for pat, label in ((RAW_PALETTE, "raw palette utility"), (HEX, "hex colour")):
+                for m in pat.finditer(line):
+                    offences.append(f"{rel}:{lineno}: {label} `{m.group()}` — use a daisyUI token")
+    return offences
+
+
+def _css_theme_names() -> set[str]:
+    css = INPUT_CSS.read_text(encoding="utf-8")
+    names: set[str] = set()
+    # Custom themes: @plugin "daisyui/theme" { name: "labase-light"; ... }
+    names.update(re.findall(r'name:\s*"([^"]+)"', css))
+    # Built-in roster: @plugin "daisyui" { themes: light, dark, …; }
+    block = re.search(r'@plugin\s+"daisyui"\s*\{(.*?)\}', css, re.DOTALL)
+    if block:
+        listed = re.search(r"themes:\s*(.*?);", block.group(1), re.DOTALL)
+        if listed:
+            names.update(t.strip() for t in listed.group(1).split(",") if t.strip())
+    return names
+
+
+def _appearance_themes() -> set[str]:
+    # Parsed by regex rather than importing/ast-parsing the module: keeps the guard
+    # free of app imports and independent of the runner's Python (appearance.py uses
+    # PEP 758 unparenthesized `except`, which only parses on 3.14+).
+    src = APPEARANCE.read_text(encoding="utf-8")
+    block = re.search(r"THEMES\s*=\s*\[(.*?)\]", src, re.DOTALL)
+    if not block:
+        raise SystemExit(f"{APPEARANCE.relative_to(ROOT)}: THEMES assignment not found")
+    return set(re.findall(r'"([^"]+)"', block.group(1)))
+
+
+def check_theme_sync() -> list[str]:
+    css = _css_theme_names()
+    py = _appearance_themes()
+    if css == py:
+        return []
+    only_css = ", ".join(sorted(css - py)) or "—"
+    only_py = ", ".join(sorted(py - css)) or "—"
+    return [
+        "theme list drift between input.css and appearance.py THEMES:",
+        f"  only in input.css: {only_css}",
+        f"  only in appearance.py: {only_py}",
+    ]
+
+
+def main() -> int:
+    offences = scan_colours() + check_theme_sync()
+    if offences:
+        print("Design-token check failed:\n", file=sys.stderr)
+        for line in offences:
+            print(f"  {line}", file=sys.stderr)
+        print(
+            "\nStyling must go through daisyUI semantic tokens "
+            "(base-*, primary, success…). See README 'Styling'.",
+            file=sys.stderr,
+        )
+        return 1
+    print("Design tokens OK: no raw palette/hex, theme lists in sync.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/static/css/input.css
+++ b/static/css/input.css
@@ -37,18 +37,114 @@
 @import "tailwindcss";
 @source "../../apps/**/templates/**/*.html";
 
+/* Built-in daisyUI themes kept enabled as an admin-selectable roster (a product built
+   on this base may adopt any of them). The signature identity lives in the two custom
+   `labase-*` themes below, which are the actual light/dark defaults. Keep this list in
+   sync with THEMES in apps/console/contract/appearance.py — enforced by
+   scripts/check_design_tokens.py. */
 @plugin "daisyui" {
-  themes:
-    light --default,
-    dark --prefersdark,
-    cupcake,
-    dracula,
-    emerald,
-    corporate,
-    synthwave,
-    retro,
-    nord,
-    business;
+  themes: light, dark, cupcake, dracula, emerald, corporate, synthwave, retro, nord, business;
+}
+
+/* ---------------------------------------------------------------------------
+   labase-light / labase-dark — the signature identity (refined-neutral,
+   editorial). The taste is in the *design variables* as much as the palette:
+   hairline 1px borders (--border), flat surfaces with no faux-3D gradient on
+   controls (--depth: 0 — elevation comes only from the deliberate shadow-sm on
+   .list-panel / .card-panel), a tight-but-not-sharp corner radius, and a single
+   restrained indigo accent (primary) with `neutral` set to ink so btn-neutral
+   reads as a near-black button. Semantic feedback colors are muted, not candy.
+   --------------------------------------------------------------------------- */
+@plugin "daisyui/theme" {
+  name: "labase-light";
+  default: true;
+  prefersdark: false;
+  color-scheme: light;
+
+  /* Surfaces — paper-white base, cool hairline greys, near-black ink */
+  --color-base-100: oklch(100% 0 0);
+  --color-base-200: oklch(98% 0.001 286);
+  --color-base-300: oklch(91.5% 0.003 286);
+  --color-base-content: oklch(21% 0.006 286);
+
+  /* The one chromatic accent — a muted deep indigo */
+  --color-primary: oklch(48% 0.105 264);
+  --color-primary-content: oklch(98% 0.005 264);
+
+  /* Secondary = quiet slate, not a second hue */
+  --color-secondary: oklch(45% 0.015 286);
+  --color-secondary-content: oklch(98% 0 0);
+
+  /* Accent stays in the primary family (no rainbow) */
+  --color-accent: oklch(55% 0.1 264);
+  --color-accent-content: oklch(98% 0.005 264);
+
+  /* Neutral = ink → near-black buttons/badges (the editorial move) */
+  --color-neutral: oklch(22% 0.006 286);
+  --color-neutral-content: oklch(98% 0 0);
+
+  /* Feedback — muted, so status never fights the monochrome */
+  --color-info: oklch(58% 0.09 240);
+  --color-info-content: oklch(98% 0 0);
+  --color-success: oklch(60% 0.11 150);
+  --color-success-content: oklch(98% 0 0);
+  --color-warning: oklch(72% 0.13 75);
+  --color-warning-content: oklch(21% 0.02 75);
+  --color-error: oklch(58% 0.17 27);
+  --color-error-content: oklch(98% 0 0);
+
+  /* Design language — tight radius, hairline border, flat elevation */
+  --radius-selector: 0.375rem;
+  --radius-field: 0.375rem;
+  --radius-box: 0.625rem;
+  --size-selector: 0.25rem;
+  --size-field: 0.25rem;
+  --border: 1px;
+  --depth: 0;
+  --noise: 0;
+}
+
+@plugin "daisyui/theme" {
+  name: "labase-dark";
+  default: false;
+  prefersdark: true;
+  color-scheme: dark;
+
+  /* Surfaces — near-black (not pure black), lifted hairline greys */
+  --color-base-100: oklch(18% 0.004 286);
+  --color-base-200: oklch(21% 0.005 286);
+  --color-base-300: oklch(27% 0.006 286);
+  --color-base-content: oklch(92% 0.003 286);
+
+  --color-primary: oklch(68% 0.12 264);
+  --color-primary-content: oklch(18% 0.02 264);
+
+  --color-secondary: oklch(72% 0.015 286);
+  --color-secondary-content: oklch(18% 0 0);
+
+  --color-accent: oklch(72% 0.1 264);
+  --color-accent-content: oklch(18% 0.02 264);
+
+  --color-neutral: oklch(28% 0.006 286);
+  --color-neutral-content: oklch(92% 0 0);
+
+  --color-info: oklch(70% 0.09 240);
+  --color-info-content: oklch(18% 0 0);
+  --color-success: oklch(70% 0.11 150);
+  --color-success-content: oklch(18% 0 0);
+  --color-warning: oklch(78% 0.13 75);
+  --color-warning-content: oklch(20% 0.02 75);
+  --color-error: oklch(68% 0.16 27);
+  --color-error-content: oklch(18% 0 0);
+
+  --radius-selector: 0.375rem;
+  --radius-field: 0.375rem;
+  --radius-box: 0.625rem;
+  --size-selector: 0.25rem;
+  --size-field: 0.25rem;
+  --border: 1px;
+  --depth: 0;
+  --noise: 0;
 }
 
 @theme {
@@ -268,54 +364,78 @@
     @apply card bg-base-100 border border-base-300 shadow-sm;
   }
 
-  /* Markdown body — styles generated HTML from mistune (child elements carry no classes) */
+  /* Type scale — the shared heading/meta ramp. Templates use these instead of
+     hand-spelling text sizes, so titles stay consistent across every app. */
+  .page-title {
+    @apply text-2xl font-semibold tracking-tight text-base-content;
+  }
+  .section-title {
+    @apply text-lg font-semibold text-base-content;
+  }
+  .subsection-title {
+    @apply text-sm font-semibold text-base-content;
+  }
+  .eyebrow {
+    @apply text-xs font-semibold uppercase tracking-wide text-base-content/70;
+  }
+  .meta-text {
+    @apply text-xs text-base-content/60;
+  }
+
+  /* Square icon chip used on overview / summary cards (single-accent). */
+  .icon-badge {
+    @apply flex h-9 w-9 flex-none items-center justify-center rounded-field bg-primary/10 text-primary;
+  }
+
+  /* Markdown body — styles generated HTML from mistune (child elements carry no
+     classes). Token-driven so it follows any active theme, including dark. */
   .md-body h1 {
-    @apply text-2xl font-semibold text-gray-900 mb-4 mt-6;
+    @apply text-2xl font-semibold text-base-content mb-4 mt-6;
   }
   .md-body h2 {
-    @apply text-xl font-semibold text-gray-800 mb-3 mt-5;
+    @apply text-xl font-semibold text-base-content mb-3 mt-5;
   }
   .md-body h3 {
-    @apply text-lg font-medium text-gray-800 mb-2 mt-4;
+    @apply text-lg font-medium text-base-content mb-2 mt-4;
   }
   .md-body p {
-    @apply text-sm text-gray-700 leading-relaxed mb-3;
+    @apply text-sm text-base-content/80 leading-relaxed mb-3;
   }
   .md-body ul {
-    @apply list-disc pl-5 mb-3 space-y-1 text-sm text-gray-700;
+    @apply list-disc pl-5 mb-3 space-y-1 text-sm text-base-content/80;
   }
   .md-body ol {
-    @apply list-decimal pl-5 mb-3 space-y-1 text-sm text-gray-700;
+    @apply list-decimal pl-5 mb-3 space-y-1 text-sm text-base-content/80;
   }
   .md-body li {
     @apply leading-relaxed;
   }
   .md-body a {
-    @apply text-indigo-600 hover:text-indigo-800 underline;
+    @apply text-primary hover:text-primary/80 underline;
   }
   .md-body pre {
-    @apply bg-gray-50 border border-gray-200 rounded-lg p-4 overflow-auto mb-3 text-sm font-mono;
+    @apply bg-base-200 border border-base-300 rounded-box p-4 overflow-auto mb-3 text-sm font-mono;
   }
   .md-body code {
-    @apply bg-gray-100 text-gray-800 text-xs px-1.5 py-0.5 rounded font-mono;
+    @apply bg-base-200 text-base-content text-xs px-1.5 py-0.5 rounded-field font-mono;
   }
   .md-body pre code {
     @apply bg-transparent p-0;
   }
   .md-body blockquote {
-    @apply border-l-4 border-gray-200 pl-4 italic text-gray-500 mb-3;
+    @apply border-l-4 border-base-300 pl-4 italic text-base-content/60 mb-3;
   }
   .md-body hr {
-    @apply border-gray-200 my-6;
+    @apply border-base-300 my-6;
   }
   .md-body table {
     @apply w-full text-sm border-collapse mb-3;
   }
   .md-body th {
-    @apply text-left font-semibold text-gray-700 border-b border-gray-200 pb-2 pr-4;
+    @apply text-left font-semibold text-base-content/80 border-b border-base-300 pb-2 pr-4;
   }
   .md-body td {
-    @apply border-b border-gray-100 py-2 pr-4;
+    @apply border-b border-base-300/60 py-2 pr-4;
   }
 
   /* CodeMirror 6 editor wrapper — mimics .input appearance */
@@ -373,8 +493,8 @@
   align-items: center;
   gap: 2px;
   padding: 5px 8px;
-  background: #1e1e2e;
-  border-bottom: 1px solid #0f0f1a;
+  background: var(--color-base-200);
+  border-bottom: 1px solid var(--color-base-300);
   flex-wrap: wrap;
 }
 .cm-toolbar-btn {
@@ -390,7 +510,7 @@
   font-size: 0.65rem;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-weight: 700;
-  color: #9ca3af;
+  color: color-mix(in oklch, var(--color-base-content) 65%, transparent);
   cursor: pointer;
   transition:
     background 0.12s,
@@ -402,14 +522,14 @@
   font-size: 0.95rem;
 }
 .cm-toolbar-btn:hover {
-  background: #2d2d44;
-  color: #4ade80;
+  background: var(--color-base-300);
+  color: var(--color-primary);
 }
 .cm-toolbar-sep {
   display: inline-block;
   width: 1px;
   height: 14px;
-  background: #374151;
+  background: var(--color-base-300);
   margin: 0 4px;
   flex-shrink: 0;
 }
@@ -437,10 +557,11 @@
   transition: transform 0.45s cubic-bezier(0.2, 0.7, 0.2, 1);
 }
 .paper {
-  background: radial-gradient(120% 120% at 0 0, #fff 0%, #fbfbfd 60%, #f3f4f8 100%);
+  background: var(--color-base-100);
+  border: 1px solid var(--color-base-300);
   box-shadow:
-    0 18px 40px -18px rgba(15, 23, 42, 0.35),
-    0 2px 8px -2px rgba(15, 23, 42, 0.12);
+    0 1px 2px oklch(0% 0 0 / 0.06),
+    0 12px 32px -16px oklch(0% 0 0 / 0.18);
 }
 .lcard.flying {
   transition:


### PR DESCRIPTION
The GUI was consistent but generic: ten stock daisyUI themes (no committed
default), design variables left at library defaults, ad-hoc heading sizes, and a
few CSS blocks bypassing the token system.

Identity
- Add signature custom themes labase-light (default) / labase-dark (prefersdark)
  via daisyUI 5 @plugin "daisyui/theme": editorial neutral — hairline 1px borders,
  flat elevation (--depth:0), tight radius, a single muted indigo accent, ink
  neutral, muted feedback colours. The full built-in roster stays enabled as an
  admin-selectable feature; only the default now carries an identity.

Harmony / correctness
- Route .md-body, .cm-toolbar and the learning .paper card through semantic tokens
  so they follow any active theme (they were hardcoded light and broke in dark).
- Add a shared type scale (.page-title/.section-title/.subsection-title/.eyebrow/
  .meta-text) and .icon-badge; sweep every app template onto them and fold a
  re-spelled .list-panel chain (calendar) back into the class.
- Single-accent overview/metric cards: drop the per-call colour and the
  indigo/emerald/amber alias layer.
- Drop the gratuitous logo glow on the public shell.

Guardrail
- scripts/check_design_tokens.py (wired into `make lint`) fails on raw Tailwind
  palette utilities / hex in templates and the CSS component layer, and asserts the
  input.css theme list matches appearance.THEMES so the two never drift.

Note: appearance.py's unparenthesized `except` is valid Python 3.14 (PEP 758); the
styleguide theme test now expects labase-light.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013vPoRXXM4UhudhT97SXnTP